### PR TITLE
Escape XML characters (in Stage name)

### DIFF
--- a/BPF To Visio/Classes/Shape.cs
+++ b/BPF To Visio/Classes/Shape.cs
@@ -218,12 +218,17 @@ namespace LinkeD365.BPFToVisio
             line.Connect(this, child, curChild, noChild);
         }
 
+        private static string XmlString(string text)
+        {
+            return new XElement("t", text).LastNode.ToString();
+        }
+
         protected void AddProp(string name, string value)
         {
             //  if (Props.ha)
             var element = Props.Elements().FirstOrDefault(el => el.Attributes().Any(at => at.Name == "N" && at.Value == name));
-            if (element != null) element.ReplaceWith(XElement.Parse("<Row N='" + name + "'> <Cell N='Value' V='" + value + "' U='STR'/></Row>"));
-            else Props.Add(XElement.Parse("<Row N='" + name + "'> <Cell N='Value' V='" + value + "' U='STR'/></Row>"));
+            if (element != null) element.ReplaceWith(XElement.Parse("<Row N='" + name + "'> <Cell N='Value' V='" + XmlString(value) + "' U='STR'/></Row>"));
+            else Props.Add(XElement.Parse("<Row N='" + name + "'> <Cell N='Value' V='" + XmlString(value) + "' U='STR'/></Row>"));
         }
 
         protected void AddType(string value)


### PR DESCRIPTION
This seems to fix the issue with ampersand in the stage title.  I'm not sure if it's the best way to escape a string to valid XML - the idea was liberated from https://weblog.west-wind.com/posts/2018/Nov/30/Returning-an-XML-Encoded-String-in-NET#reading-an-encoded-xml-value 

I hope this helps.  Thanks again for the very cool tools.